### PR TITLE
Don't prepend the host URL if the URI already validates as a URL

### DIFF
--- a/EventListener/JmsSerializerSubscriber.php
+++ b/EventListener/JmsSerializerSubscriber.php
@@ -134,7 +134,7 @@ class JmsSerializerSubscriber implements EventSubscriberInterface
 
                     if ($property->getValue($event->getObject())) {
                         $uri = $this->storage->resolveUri($object, $vichSerializableAnnotation->getField());
-                        if ($vichSerializableAnnotation->isIncludeHost()) {
+                        if ($vichSerializableAnnotation->isIncludeHost() && false === \filter_var($uri, FILTER_VALIDATE_URL)) {
                             $uri = $this->getHostUrl().$uri;
                         }
                     }


### PR DESCRIPTION
When using a storage abstraction such as [Gaufrette's S3 adapter](https://github.com/KnpLabs/KnpGaufretteBundle/blob/master/Resources/docs/adapters/awss3.md), the URI prefix has to be configured as an absolute URL (e.g. https://s3-eu-west-1.amazonaws.com/example.com/avatars). With `includeHost=true` this results in the following URL being serialized: https://example.comhttps://s3-eu-west-1.amazonaws.com/example.com/avatars/5b322fdd.png

Generally you'd instead use `includeHost=false` but I think I've found an edge-case when you have Vich mappings that differ between environments, e.g. serving files locally in dev but from S3 in prod. In this case, if our software is an API which a local device queries to display a list of users with their avatars, the dev environment can't respond with relative URLs.