### PR TITLE
[UPDATE] Prevent error when using custom type

### DIFF
--- a/EventListener/JmsSerializerSubscriber.php
+++ b/EventListener/JmsSerializerSubscriber.php
@@ -88,7 +88,7 @@ class JmsSerializerSubscriber implements EventSubscriberInterface
     public function onPreSerialize(PreSerializeEvent $event): void
     {
         $object = $event->getObject();
-        if(!is_object($object)) {
+        if (!is_object($object)) {
             return;
         }
 
@@ -154,7 +154,7 @@ class JmsSerializerSubscriber implements EventSubscriberInterface
     public function onPostSerialize(ObjectEvent $event): void
     {
         $object = $event->getObject();
-        if(!is_object($object)) {
+        if (!is_object($object)) {
             return;
         }
 

--- a/EventListener/JmsSerializerSubscriber.php
+++ b/EventListener/JmsSerializerSubscriber.php
@@ -88,6 +88,9 @@ class JmsSerializerSubscriber implements EventSubscriberInterface
     public function onPreSerialize(PreSerializeEvent $event): void
     {
         $object = $event->getObject();
+        if(!is_object($object)) {
+            return;
+        }
 
         if ($object instanceof Proxy && !$object->__isInitialized()) {
             $object->__load();
@@ -151,6 +154,9 @@ class JmsSerializerSubscriber implements EventSubscriberInterface
     public function onPostSerialize(ObjectEvent $event): void
     {
         $object = $event->getObject();
+        if(!is_object($object)) {
+            return;
+        }
 
         if ($object instanceof Proxy && !$object->__isInitialized()) {
             $object->__load();


### PR DESCRIPTION
To be able to use custom type (that are not objects) in JMS handlers and to keep using this VichUploaderSerializationBundle i have made this little update to prevent error